### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/github-CI.yml
+++ b/.github/workflows/github-CI.yml
@@ -20,7 +20,7 @@ jobs:
       
       
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@3.04
+        uses: elgohr/Publish-Docker-Github-Action@v5
 
         with:
           name: iko90/githublesson3


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore